### PR TITLE
Add PLUGIN_ASSET_SIGN_KEY to docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ RefMD is a real-time Markdown collaboration platform that lets teams co-author d
    docker compose up -d
    ```
 2. Wait for the health checks to pass (`docker compose ps`) and open `http://localhost:3000` for the web app (`api` is exposed on `http://localhost:8888`).
-3. Sign up for a new account (email + password) and start editing. Update `JWT_SECRET` / `ENCRYPTION_KEY` in the compose file or an `.env` file before running in production.
+3. Sign up for a new account (email + password) and start editing. Update `JWT_SECRET` / `ENCRYPTION_KEY` / `PLUGIN_ASSET_SIGN_KEY`  in the compose file or an `.env` file before running in production.
 
 For local development or when you need to rebuild the images, use `docker compose -f docker-compose.dev.yml up --build` instead.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       UPLOADS_DIR: /data/uploads
       UPLOAD_MAX_BYTES: 26214400
       PLUGINS_DIR: /app/plugins
+      PLUGIN_ASSET_SIGN_KEY: change-me-please
     ports:
       - "8888:8888"
     depends_on:


### PR DESCRIPTION
Don't know if this intended but couldn't run the source straight away after cloning, had to add PLUGIN_ASSET_SIGN_KEY in the Docker compose file else the api fails. I have added them and also included it in the README.md.